### PR TITLE
Temporarily drop JDK9 building until ivy workaround for JDK9 bugs are…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 sudo: false
 jdk:
 - openjdk8
-- oraclejdk9
 scala:
 - 2.11.11
 - 2.12.4
@@ -20,7 +19,3 @@ before_cache:
 env:
   global:
     - DEFAULT_TIMEOUT_MILLIS=300 #Reactive Streams testkit timeout for async ops
-matrix:
-  exclude:
-  - jdk: oraclejdk9
-    scala: 2.11.11

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version = 1.0.2
+sbt.version = 1.0.3
 


### PR DESCRIPTION
… in place